### PR TITLE
Bug : topbar 고정 안됨 해결

### DIFF
--- a/src/About/components/AboutUsSection.tsx
+++ b/src/About/components/AboutUsSection.tsx
@@ -32,7 +32,7 @@ export default AboutUsSection;
 
 const BG = styled(motion.div).attrs({ id: "aboutus-section" })`
   width: 100%;
-  height: 100vh;
+  min-height: 100vh;
 
   scroll-snap-align: start;
   scroll-snap-stop: always; // 스크롤 할 때에만 snap 적용
@@ -61,13 +61,12 @@ const BG = styled(motion.div).attrs({ id: "aboutus-section" })`
   ${media.small`
    /* 초기화 */
    scroll-snap-align: none;
-    scroll-snap-stop: normal;
+   scroll-snap-stop: normal;
 
-    width: 100%;
-    height: auto;
+    min-height: auto;
     
     background: none;
-    background-size: contain;
+    background-size: cover;
     background-repeat: no-repeat;
 
     justify-content: flex-start;
@@ -88,6 +87,8 @@ const BGBottom = styled.div`
   align-items: center;
   gap: 3rem;
 
+  position: relative;
+
   background: linear-gradient(0deg, rgba(0, 0, 0, 0.9) 0%, rgba(0, 0, 0, 0) 100%);
 
   ${media.medium`
@@ -95,13 +96,15 @@ const BGBottom = styled.div`
   `}
 
   ${media.small`
-    margin-top: 15rem;
-    min-height: 37rem;
+    height: auto;
+    margin-top: 5rem;
     max-height: 40rem;
+    min-height: 37rem;
 
     justify-content: flex-start;
     padding-top: 5rem;
     align-items: flex-start;
+    gap: 5rem;
 
     position: relative;
 
@@ -110,7 +113,8 @@ const BGBottom = styled.div`
     background-repeat: no-repeat;
 
     &::after {
-      height: 100%;
+      height: auto;
+      max-height: 40rem;
       content: "";
       position: absolute;
       bottom: 0;

--- a/src/About/components/AboutUsSection.tsx
+++ b/src/About/components/AboutUsSection.tsx
@@ -46,7 +46,7 @@ const BG = styled(motion.div).attrs({ id: "aboutus-section" })`
 
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
+  justify-content: flex-end;
   align-items: center;
 
   &::after {
@@ -92,19 +92,18 @@ const BGBottom = styled.div`
   background: linear-gradient(0deg, rgba(0, 0, 0, 0.9) 0%, rgba(0, 0, 0, 0) 100%);
 
   ${media.medium`
-    gap: 1rem;
+    gap: 5rem;
   `}
 
   ${media.small`
     height: auto;
     margin-top: 5rem;
     max-height: 40rem;
-    min-height: 37rem;
+    min-height: 35rem;
 
     justify-content: flex-start;
     padding-top: 5rem;
     align-items: flex-start;
-    gap: 5rem;
 
     position: relative;
 

--- a/src/About/components/ActivitySection.tsx
+++ b/src/About/components/ActivitySection.tsx
@@ -56,9 +56,9 @@ const BG = styled(motion.div).attrs({ id: "activity-section" })`
   scroll-snap-stop: always; // 스크롤 할 때에만 snap 적용
 
   ${media.small`
-    height: auto;
+    height: auto; // 모바일에선 100vh 제거
+    overflow-y: scroll; 
 
-    /* 초기화 */
     scroll-snap-align: none;
     scroll-snap-stop: normal;
   `}

--- a/src/About/components/TeamSection.tsx
+++ b/src/About/components/TeamSection.tsx
@@ -62,6 +62,11 @@ const BG = styled(motion.div).attrs({ id: "team-section" })`
 
   scroll-snap-align: start;
   scroll-snap-stop: always; // 스크롤 할 때에만 snap 적용
+
+  ${media.small`
+    scroll-snap-align: none;
+    scroll-snap-stop: normal;
+  `}
 `;
 
 const Header = styled.div`

--- a/src/About/index.tsx
+++ b/src/About/index.tsx
@@ -3,7 +3,6 @@ import AboutUsSection from "./components/AboutUsSection";
 import ActivitySection from "./components/ActivitySection";
 import TeamSection from "./components/TeamSection";
 import TopBar from "../common/components/TopBar";
-import media from "../common/styles/media";
 
 const About = () => {
   return (

--- a/src/About/index.tsx
+++ b/src/About/index.tsx
@@ -2,8 +2,8 @@ import styled from "styled-components";
 import AboutUsSection from "./components/AboutUsSection";
 import ActivitySection from "./components/ActivitySection";
 import TeamSection from "./components/TeamSection";
-import media from "../common/styles/media";
 import TopBar from "../common/components/TopBar";
+import media from "../common/styles/media";
 
 const About = () => {
   return (
@@ -25,13 +25,4 @@ const SnapContainer = styled.div.attrs({ id: "snap-container" })`
   overflow-y: scroll;
   scroll-snap-type: y mandatory;
   scroll-behavior: smooth;
-
-  ${media.small`
-    height: auto;
-
-    scroll-snap-align : none;
-    scroll-behavior: normal;
-
-    overflow-y: hidden;
-  `}
 `;

--- a/src/Project/Detail/components/ProjectDetailComponent.tsx
+++ b/src/Project/Detail/components/ProjectDetailComponent.tsx
@@ -1,7 +1,6 @@
 import { useNavigate, useParams } from "react-router-dom";
 import styled from "styled-components";
 import Arrow from "../../../common/assets/arrow_down.svg?react";
-import TopBar from "../../../common/components/TopBar";
 import Footer from "../../../common/components/Footer";
 import { projectData } from "../constants/projectData";
 import media from "../../../common/styles/media";
@@ -76,7 +75,6 @@ const ProjectDetailComponent = () => {
 
   return (
     <>
-      <TopBar />
       <BG>
         <BackBtnWrapper onClick={() => navigate(-1)}>
           <BackArrow />
@@ -135,7 +133,6 @@ const BG = styled.div`
   justify-content: center;
   align-items: flex-start;
 
-  margin-top: 10rem;
   padding-bottom: 8rem;
 `;
 

--- a/src/Project/Detail/index.tsx
+++ b/src/Project/Detail/index.tsx
@@ -1,10 +1,17 @@
+import styled from "styled-components";
+import TopBar from "../../common/components/TopBar";
 import ProjectDetailComponent from "./components/ProjectDetailComponent";
 const ProjectDetail = () => {
   return (
-    <div>
+    <Container>
+      <TopBar type="project" />
       <ProjectDetailComponent />
-    </div>
+    </Container>
   );
 };
 
 export default ProjectDetail;
+
+const Container = styled.div`
+  position: relative;
+`;

--- a/src/Project/components/ProjectMain.tsx
+++ b/src/Project/components/ProjectMain.tsx
@@ -55,8 +55,8 @@ const ProjectMain = () => {
 
   return (
     <>
+      <TopBar type="project" />
       <BG>
-        <TopBar />
         <TitleContainer>
           OUR PROJECTS
           <KorTitle>최근 진행된 프로젝트 몰아보기</KorTitle>
@@ -107,7 +107,6 @@ const BG = styled.div`
   flex-direction: column;
 
   width: 100vw;
-  margin: 12rem 0;
   padding: 3rem 0;
 
   background: url(${BgImg});
@@ -172,10 +171,12 @@ const PaginationContainer = styled.div`
 `;
 
 const PageButton = styled.button<{ $isActive: boolean | undefined }>`
+  margin: none;
+  border: none;
+  padding: none;
+
   width: 4.4rem;
   height: 4.4rem;
-  margin: auto auto;
-  border: none;
   transition: background-color 0.3s ease-in-out;
 
   display: flex;

--- a/src/Recruit/components/BodySection.tsx
+++ b/src/Recruit/components/BodySection.tsx
@@ -6,7 +6,6 @@ import { motion } from "framer-motion";
 import media from "../../common/styles/media";
 import RoadmapImg from "../assets/roadmap.png";
 import PartBox from "./PartBox";
-// import bgImg from "../assets/recruitCover/bgImg.png";
 
 const Body = () => {
   const { isExpired } = useCountDownStore();

--- a/src/common/components/TopBar.tsx
+++ b/src/common/components/TopBar.tsx
@@ -19,7 +19,7 @@ const TopBar = ({ type }: TopBarProps) => {
 
   return (
     <>
-      <TopBarContainer $isRecruit={isRecruitActive}>
+      <TopBarContainer $isRecruit={isRecruitActive} $type={type}>
         <Link to="/">
           <LogoContainer>
             <Logo style={{ width: "2rem" }} />
@@ -39,8 +39,8 @@ const TopBar = ({ type }: TopBarProps) => {
 
 export default TopBar;
 
-const TopBarContainer = styled.div<{ $isRecruit: boolean }>`
-  position: absolute;
+const TopBarContainer = styled.div<{ $isRecruit: boolean; $type?: string }>`
+  position: ${({ $type }) => ($type === "project" ? "sticky" : "absolute")};
   top: 0;
   left: 0;
   right: 0;

--- a/src/common/components/TopBar.tsx
+++ b/src/common/components/TopBar.tsx
@@ -27,7 +27,11 @@ const TopBar = ({ type }: TopBarProps) => {
           </LogoContainer>
         </Link>
         <BtnContainer>
-          {type !== "recruit" && <ApplyBtn>13기 지원하기</ApplyBtn>}
+          {type !== "recruit" && (
+            <Link to="/recruit">
+              <ApplyBtn>13기 지원하기</ApplyBtn>
+            </Link>
+          )}
           <IcMenuStyled onClick={() => setIsNavOpen(true)} />
         </BtnContainer>
       </TopBarContainer>


### PR DESCRIPTION
## 📝 PR 유형
- [ ] 🚀 feature 기능 추가
- [x] 🐞 버그 발생
- [ ] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 🔔 관련된 이슈 넘버
<!-- ex) close #1 -->
close #65 

## ✅ 작업 목록
<!-- 이슈 작업한 내용 -->
1. AboutUs 페이지의 픽스 헤더를 추가했습니다.
추가적으로, 모바일에서 Activity Section의 100vh가 계속해서 영향을 미치고 있어 스크롤에 이슈가 생기는 문제를 발견하여, 알맞게 모바일 반응형 처리해주었습니다.
2. ProjectMain과 ProjectDetail 페이지의 픽스 헤더를 추가했습니다.
Project의 경우 100vh인 컨테이너가 없어 absolute한 헤더가 상단에 고정되지 않기에, props로 type을 받아 position 값을 sticky가 되도록 변경하였습니다.
```
 position: ${({ $type }) => ($type === "project" ? "sticky" : "absolute")};
```

3. 상단바의 13기 지원하기 버튼을 누르면 recruit 페이지로 이동하도록 수정하였습니다.

## 🍰 논의사항
<!-- 함께 논의하고 싶은 사항, 코드리뷰가 필요한 부분이 있다면 적어주세요. -->

## 📷 ETC
<!-- 스크린샷, GIF 등 참고 자료를 첨부해주세요. -->
### 1️⃣ AboutUs 페이지 픽스 헤더 추가 및 레이아웃 수정/정리
![화면 기록 2025-02-21 오후 4 52 43](https://github.com/user-attachments/assets/692b81ee-d4bf-43ef-9c63-a4ced40614c2)

### 2️⃣ project main 및 detail 페이지 픽스 헤더 추가 / 지원하기 버튼 리쿠르팅 페이지 연결
![화면 기록 2025-02-21 오후 4 49 18](https://github.com/user-attachments/assets/154129d7-3415-4ff7-a3df-45301e2b0e7b)



