### PR TITLE
Fix: 파트 상태 변경 시 슬릭 인덱스 초기화

### DIFF
--- a/src/Part/components/Comment.tsx
+++ b/src/Part/components/Comment.tsx
@@ -12,7 +12,7 @@ import media from "../../common/styles/media";
 
 export default function Comment() {
   const { selectedRole } = useRoleStore();
-  const comments = commentsData[selectedRole] ?? [];
+  const [comments, setComments] = useState(commentsData[selectedRole] ?? []);
   const [currentSlide, setCurrentSlide] = useState(0);
   const [isDisabled, setIsDisabled] = useState(false);
   const sliderRef = useRef<Slider | null>(null);
@@ -51,6 +51,7 @@ export default function Comment() {
     ]
   };
 
+  // 무한 클릭 방지
   useEffect(() => {
     if (isDisabled) {
       const timeout = setTimeout(() => {
@@ -59,6 +60,15 @@ export default function Comment() {
       return () => clearTimeout(timeout);
     }
   }, [isDisabled]);
+
+
+  // 카드 인덱스 초기화
+  useEffect(() => {
+    setComments(commentsData[selectedRole] ?? []);
+    if (sliderRef.current) {
+      sliderRef.current.slickGoTo(0);
+    }
+  }, [selectedRole]);
 
   const handlePrev = () => {
     if (isDisabled || !sliderRef.current || currentSlide === 0) return;


### PR DESCRIPTION
## 📝 PR 유형
- [ ] 🚀 feature 기능 추가
- [ ] 🐞 버그 발생
- [x] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 🔔 관련된 이슈 넘버
close #79 


## ✅ 작업 목록
- 파트 상태 변경 시 슬릭 인덱스 초기화
```tsx
useEffect(() => {
    setComments(commentsData[selectedRole] ?? []);
    if (sliderRef.current) {
      sliderRef.current.slickGoTo(0);
    }
  }, [selectedRole]);
```
useEffect를 추가하여 선택된 파트가 변경될 때마다 리액트 슬릭 인덱스를 0으로 초기화합니다.
일반적인 인덱스로 접근하면 리액트 슬릭이 인식을 못 해 초기화가 안 되므로 sliderRef.current.slickGoTo로 참조하여 0으로 초기화합니다.

## 📷 ETC

https://github.com/user-attachments/assets/0bc56a61-3bab-43ef-8784-0a0b7a0b6305


